### PR TITLE
feat: add cart confirmation page with mock checkout flow

### DIFF
--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import CartItem from '@/app/ui/cart/CartItem';
+import { CartItemType, getCart } from '@/app/lib/cart';
+import Link from 'next/link';
+import { Button } from '@/app/ui/button';
+
+export default function CartPage() {
+  const [cartItems, setCartItems] = useState<CartItemType[]>([]);
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    const storedCart = getCart();
+    setCartItems(storedCart);
+    setTotal(
+      storedCart.reduce((acc, item) => acc + item.price * item.quantity, 0)
+    );
+  }, []);
+
+  const refreshCart = () => {
+    const updated = getCart();
+    setCartItems(updated);
+    setTotal(updated.reduce((acc, item) => acc + item.price * item.quantity, 0));
+  };
+
+  return (
+    <main className="p-6 max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-6">Cart Summary</h1>
+
+      {cartItems.length === 0 ? (
+        <p>Your cart is empty.</p>
+      ) : (
+        <>
+          <div className="space-y-4">
+            {cartItems.map((item) => (
+              <CartItem key={item.id} item={item} onUpdate={refreshCart} />
+            ))}
+          </div>
+
+          <div className="mt-8 text-right text-lg font-semibold">
+            Total: ${(total / 100).toFixed(2)}
+          </div>
+
+          <div className="mt-6 flex flex-col sm:flex-row justify-between items-center gap-4">
+            <Link href="/catalog">
+              <Button variant="secondary">← Continue Shopping</Button>
+            </Link>
+            <Link href="/confirmation">
+              <Button className="bg-green-600 hover:bg-green-700 text-white">
+                Proceed to Checkout
+              </Button>
+            </Link>
+          </div>
+        </>
+      )}
+    </main>
+  );
+}

--- a/src/app/components/Content.tsx
+++ b/src/app/components/Content.tsx
@@ -57,7 +57,7 @@ export default async function Content() {
           <div className="absolute left-0 top-0 h-full w-full bg-gradient-to-r from-[var(--primary)] via-[var(--primary-light)] to-transparent md:w-[50%] flex items-center px-8 md:px-16">
             <div className="text-white space-y-4 max-w-md">
               <h2 className="text-3xl md:text-4xl font-bold leading-snug">
-                Explore. Create. Bliss.
+                Explore. Create. Share.
               </h2>
               <p className="text-sm md:text-base">
                 Start selling your handmade products today.

--- a/src/app/confirmation/page.tsx
+++ b/src/app/confirmation/page.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Button } from '@/app/ui/button';
+import Link from 'next/link';
+import Image from 'next/image';
+
+export default function ConfirmationPage() {
+  useEffect(() => {
+    localStorage.removeItem('cart');
+    window.dispatchEvent(new Event('cartUpdated'));
+  }, []);
+
+  return (
+    <main className="flex flex-col items-center justify-center min-h-[70vh] text-center p-6">
+      <Image
+        src="/logos/solid-backg-square-logo.png"
+        alt="Handcrafted Haven Logo"
+        width={300}
+        height={300}
+        className="mb-6 rounded shadow-md"
+      />
+
+      <h1 className="text-2xl font-bold mb-4">
+        Thank you for your purchase!
+      </h1>
+
+      <p className="text-gray-700 max-w-md mb-6">
+        We received your order and will send you an email when your items ship.
+        Thank you for supporting our artisans — your purchase makes a difference.
+      </p>
+
+      <Link href="/">
+        <Button className="bg-[var(--secondary)] hover:bg-[var(--secondary-light)] text-black">
+          Back to Home
+        </Button>
+      </Link>
+    </main>
+  );
+}

--- a/src/app/lib/cart.ts
+++ b/src/app/lib/cart.ts
@@ -1,0 +1,49 @@
+export type CartItemType = {
+  id: string;
+  title: string;
+  price: number;
+  imageUrl: string;
+  quantity: number;
+};
+
+export function getCart(): CartItemType[] {
+  if (typeof window === 'undefined') return [];
+  const data = localStorage.getItem('cart');
+  return data ? JSON.parse(data) : [];
+}
+
+export function addToCart(newItem: CartItemType) {
+  const cart = getCart();
+  const existing = cart.find((item) => item.id === newItem.id);
+  let updatedCart;
+
+  if (existing) {
+    updatedCart = cart.map((item) =>
+      item.id === newItem.id
+        ? { ...item, quantity: item.quantity + newItem.quantity }
+        : item
+    );
+  } else {
+    updatedCart = [...cart, newItem];
+  }
+
+  localStorage.setItem('cart', JSON.stringify(updatedCart));
+
+  window.dispatchEvent(new Event('cartUpdated'));
+}
+
+export function removeFromCart(id: string) {
+  const updatedCart = getCart().filter((item) => item.id !== id);
+  localStorage.setItem('cart', JSON.stringify(updatedCart));
+
+  window.dispatchEvent(new Event('cartUpdated'));
+}
+
+export function updateQuantity(id: string, quantity: number) {
+  const updatedCart = getCart().map((item) =>
+    item.id === id ? { ...item, quantity } : item
+  );
+  localStorage.setItem('cart', JSON.stringify(updatedCart));
+
+  window.dispatchEvent(new Event('cartUpdated'));
+}

--- a/src/app/lib/useCartCount.ts
+++ b/src/app/lib/useCartCount.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getCart } from './cart';
+
+export function useCartCount() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const updateCount = () => {
+      const cart = getCart();
+      const totalItems = cart.reduce((acc, item) => acc + item.quantity, 0);
+      setCount(totalItems);
+    };
+
+    updateCount();
+
+    window.addEventListener('storage', updateCount);
+
+    window.addEventListener('cartUpdated', updateCount);
+
+    return () => {
+      window.removeEventListener('storage', updateCount);
+      window.removeEventListener('cartUpdated', updateCount);
+    };
+  }, []);
+
+  return count;
+}

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -1,6 +1,8 @@
 import postgres from 'postgres';
 import Image from "next/image";
 import Link from "next/link";
+import AddToCartButton from '@/app/ui/cart/AddToCartButton';
+
 
 const sql = postgres(process.env.DATABASE_URL!, {
   ssl: 'require',
@@ -58,6 +60,17 @@ export default async function ProductPage({ params }: { params: Promise<{ id: st
       <p className="text-gray-700 text-base">
         This is a handcrafted item with love ♥
       </p>
+      <div className="mt-8">
+        <AddToCartButton
+          product={{
+            id: product.id,
+            title: product.inv_title,
+            price: product.inv_price,
+            imageUrl: '/placeholder.png',
+            quantity: 1,
+          }}
+        />
+      </div>
     </main>
   );
 }

--- a/src/app/ui/cart/AddToCartButton.tsx
+++ b/src/app/ui/cart/AddToCartButton.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { ShoppingCart } from 'lucide-react';
+import { Button } from '@/app/ui/button';
+import { addToCart } from '@/app/lib/cart';
+
+type Props = {
+  product: {
+    id: string;
+    title: string;
+    price: number;
+    imageUrl: string;
+    quantity: number;
+  };
+};
+
+export default function AddToCartButton({ product }: Props) {
+  const handleClick = () => {
+    addToCart(product);
+  };
+
+  return (
+    <Button
+      onClick={handleClick}
+      className="flex items-center gap-2 bg-[var(--secondary)] hover:bg-[var(--secondary-light)] text-black"
+    >
+      <ShoppingCart size={16} />
+      Add to Cart
+    </Button>
+  );
+}

--- a/src/app/ui/cart/CartItem.tsx
+++ b/src/app/ui/cart/CartItem.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import Image from 'next/image';
+import { Minus, Plus, Trash2 } from 'lucide-react';
+import { CartItemType, updateQuantity, removeFromCart } from '@/app/lib/cart';
+import { useState } from 'react';
+
+export default function CartItem({
+  item,
+  onUpdate,
+}: {
+  item: CartItemType;
+  onUpdate: () => void;
+}) {
+  const [qty, setQty] = useState(item.quantity);
+
+  const handleQuantityChange = (newQty: number) => {
+    setQty(newQty);
+    updateQuantity(item.id, newQty);
+    onUpdate();
+  };
+
+  const handleRemove = () => {
+    removeFromCart(item.id);
+    onUpdate();
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-4 border-b pb-4">
+      <div className="flex items-center gap-4">
+        <Image
+          src={item.imageUrl}
+          alt={item.title}
+          width={80}
+          height={80}
+          className="rounded-md object-cover"
+        />
+        <div>
+          <h2 className="font-semibold">{item.title}</h2>
+          <p className="text-sm text-gray-500">
+            ${(item.price / 100).toFixed(2)} each
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => handleQuantityChange(Math.max(1, qty - 1))}
+          className="p-1 bg-gray-200 rounded hover:bg-gray-300"
+        >
+          <Minus size={16} />
+        </button>
+        <span className="px-2">{qty}</span>
+        <button
+          onClick={() => handleQuantityChange(qty + 1)}
+          className="p-1 bg-gray-200 rounded hover:bg-gray-300"
+        >
+          <Plus size={16} />
+        </button>
+        <button
+          onClick={handleRemove}
+          className="ml-4 p-1 bg-red-100 text-red-600 rounded hover:bg-red-200"
+        >
+          <Trash2 size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/ui/catalog/ProductCard.tsx
+++ b/src/app/ui/catalog/ProductCard.tsx
@@ -1,9 +1,10 @@
+'use client';
+
 import Image from 'next/image';
 import Link from 'next/link';
 import { Button } from '@ui/button';
 import { ShoppingCart } from 'lucide-react';
-
-
+import { addToCart } from '@/app/lib/cart';
 
 export type ProductCardProps = {
   id: string;
@@ -11,12 +12,22 @@ export type ProductCardProps = {
   price: number;
   imageUrl: string;
   seller: {
-    id: string;
-    name: string;
+  id: string;
+  name: string;
   };
 };
 
 export default function ProductCard({ product }: { product: ProductCardProps }) {
+  const handleAddToCart = () => {
+    addToCart({
+      id: product.id,
+      title: product.title,
+      price: product.price,
+      imageUrl: product.imageUrl,
+      quantity: 1,
+    });
+  };
+
   return (
     <div className="relative rounded-xl bg-white p-4 shadow-md hover:shadow-lg transition-transform duration-200 hover:scale-[1.02] border border-gray-100">
       <div className="overflow-hidden rounded-lg bg-gray-100 h-48">
@@ -43,13 +54,15 @@ export default function ProductCard({ product }: { product: ProductCardProps }) 
           </Link>
         </p>
         <div className="mt-4">
-            <Link href={`/products/${product.id}`}>
-                <Button>View Product</Button>
-            </Link>
+          <Link href={`/products/${product.id}`}>
+            <Button>View Product</Button>
+          </Link>
         </div>
       </div>
+
       <button
         type="button"
+        onClick={handleAddToCart}
         className="absolute bottom-4 right-4 bg-gray-100 hover:bg-gray-200 p-2 rounded-full shadow-md"
       >
         <ShoppingCart size={16} />

--- a/src/app/ui/nav.tsx
+++ b/src/app/ui/nav.tsx
@@ -1,10 +1,11 @@
-"use client";
+'use client';
 
 import { BookImage, House, Package, ShoppingCart } from "lucide-react";
 import clsx from "clsx";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import React from "react";
+import { useCartCount } from "@/app/lib/useCartCount";
 
 const links = [
   { name: "Home", href: "/", icon: House },
@@ -15,18 +16,22 @@ const links = [
 
 export default function Nav() {
   const pathname = usePathname();
+  const cartCount = useCartCount();
+
   return (
     <nav className="flex items-center gap-2">
       <ul className="flex gap-1">
         {links.map((link) => {
           const LinkIcon = link.icon;
+          const isCart = link.name === "Cart";
+
           return (
             <Link
               key={link.name}
               href={link.href}
-              title={link.name} // Tooltip on hover
+              title={link.name}
               className={clsx(
-                "text-white p-3 rounded-md transition-all ease-in-out duration-300",
+                "relative text-white p-3 rounded-md transition-all ease-in-out duration-300",
                 {
                   "bg-[var(--secondary)]": pathname === link.href,
                   "hover:bg-[var(--secondary)]": pathname !== link.href,
@@ -34,6 +39,11 @@ export default function Nav() {
               )}
             >
               <LinkIcon className="w-5 h-5" />
+              {isCart && cartCount > 0 && (
+                <span className="absolute -top-1 -right-1 bg-red-600 text-white text-xs font-bold w-5 h-5 rounded-full flex items-center justify-center">
+                  {cartCount}
+                </span>
+              )}
             </Link>
           );
         })}


### PR DESCRIPTION
- Created a full shopping cart page at /cart. Displays all items in the cart with image, quantity controls, and delete button. Shows the total price and a clear call-to-action
- Added "Proceed to Checkout" button that redirects to a mock confirmation page
- Confirmation page (/confirmation) clears the cart and shows a thank-you message
- Includes brand logo and “Back to Home” button
- Cart icon in the navbar now shows a red badge with the total number of items